### PR TITLE
ロンをスルーしてもエラー落ちしないようにした

### DIFF
--- a/app/views/games/mahjong_table/events/_confirm_ron.html.erb
+++ b/app/views/games/mahjong_table/events/_confirm_ron.html.erb
@@ -16,7 +16,7 @@
                     params: {
                       event: "confirm_ron",
                       discarded_tile_id: @discarded_tile_id,
-                      ron_player_ids: @ron_eligible_players_ids - [ @game.user_player.id ]
+                      ron_player_ids: (@ron_eligible_players_ids - [ @game.user_player.id ]).presence || [ "" ]
                     },
                     form: { data: { testid: "through" } },
                     class: "rounded border px-2 py-1" %>


### PR DESCRIPTION
- #207 

- 空の配列はサーバーに送れないためnilになる
- スルーしてaiもロンできない場合、空文字を含む配列を送るようにしてエラー落ちを回避
- 統合テストでは、paramsを直接空配列で指定しているため、テストが通っていた。
- テストも空文字を含む配列を送るように変更