### PR TITLE
top_tileメソッドを修正した

### DIFF
--- a/app/models/honba.rb
+++ b/app/models/honba.rb
@@ -19,8 +19,7 @@ class Honba < ApplicationRecord
   after_create :create_tile_orders_and_step
 
   def top_tile
-    order = draw_count - kan_count
-    tile_orders.find_by(order:).tile
+    tile_orders.find_by(order: draw_count).tile
   end
 
   def rinshan_tile

--- a/test/models/honba_test.rb
+++ b/test/models/honba_test.rb
@@ -66,16 +66,9 @@ class HonbaTest < ActiveSupport::TestCase
   end
 
   test '#top_tile' do
-    @honba.draw_count = 10
-    @honba.kan_count = 0
-    top_tile_order = @honba.draw_count - @honba.kan_count
-    expected = @honba.tile_orders.find_by(order: top_tile_order).tile
-    assert_equal expected, @honba.top_tile
-
-    @honba.draw_count = 20
-    @honba.kan_count = 2
-    top_tile_order = @honba.draw_count - @honba.kan_count
-    expected = @honba.tile_orders.find_by(order: top_tile_order).tile
+    draw_count = 10
+    @honba.update!(draw_count:)
+    expected = @honba.tile_orders.find_by(order: draw_count).tile
     assert_equal expected, @honba.top_tile
   end
 


### PR DESCRIPTION
- #273 

- draw_countのみでtile_orderからツモ牌を取得するようにした
- カンした時は、draw_countは増えない